### PR TITLE
add language server to docker-compose config

### DIFF
--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -14,6 +14,12 @@ services:
       - GH_CLIENT_ID=
       - GH_CLIENT_SECRET=
       - GH_CB_URL=
+      - GL_CLIENT_ID=
+      - GL_CLIENT_SECRET=
+      - GL_CB_URL=
+      - BB_CLIENT_ID=
+      - BB_CLIENT_SECRET=
+      - BB_CB_URL=
       - JWT_SECRET=
       - PORT=
       - DATABASE_URL=
@@ -28,6 +34,11 @@ services:
       - userdata-data:/var/lib/postgresql/data/
     ports:
       - ':'
+
+  language-server:
+    image: 'ohtuamandus/robot-language-server'
+    ports:
+      - ':5555'
 
   watchtower:
     image: v2tec/watchtower

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,5 +34,10 @@ services:
     ports:
       - '5432:5432'
 
+  language-server:
+    image: 'ohtuamandus/robot-language-server'
+    ports:
+      - '5555:5555'
+
 volumes:
   userdata-data:


### PR DESCRIPTION
- Starts language server to port 5555 with docker-compose up
- Adds missing configurations to docker-compose.server.yml