### PR TITLE
Solve multiple conflicts

### DIFF
--- a/backend/src/utils/utils.ts
+++ b/backend/src/utils/utils.ts
@@ -8,8 +8,6 @@ import { sanitizeCommitMessage } from './sanitize'
 import { ServiceName, ServiceTokenType } from '../types/service'
 import { AppContext, UserForCommit } from '../types/user'
 
-
-
 const execProm = promisify(exec)
 
 export const validateBranchName = async (branchName: string): Promise<void> => {
@@ -24,8 +22,10 @@ const runShellCommand = async (command: string): Promise<string> => {
   }
 }
 
-export const pipe = <T>(...fns: Array<(a: T) => T>) => (x: T): T =>
-  fns.reduce((value, func) => func(value), x)
+export const pipe =
+  <T>(...fns: Array<(a: T) => T>) =>
+  (x: T): T =>
+    fns.reduce((value, func) => func(value), x)
 
 export const getRepositoryFromFilePath = (filePath: string): string => {
   return filePath.split('/').slice(2, 4).join('/')
@@ -47,7 +47,10 @@ interface ServiceProps {
   appContext: AppContext
 }
 
-export const getServiceTokenFromAppContext = ({ service, appContext }: ServiceProps): ServiceTokenType | undefined => {
+export const getServiceTokenFromAppContext = ({
+  service,
+  appContext,
+}: ServiceProps): ServiceTokenType | undefined => {
   let tokenToReturn: ServiceTokenType | undefined
   switch (service) {
     case 'gitlab':
@@ -56,7 +59,8 @@ export const getServiceTokenFromAppContext = ({ service, appContext }: ServicePr
     case 'bitbucket':
       tokenToReturn = appContext.bitbucketToken as ServiceTokenType
       break
-    default: tokenToReturn = appContext.githubToken as ServiceTokenType
+    default:
+      tokenToReturn = appContext.githubToken as ServiceTokenType
   }
   return tokenToReturn
 }
@@ -81,22 +85,18 @@ export const getRepoLocationFromUrlString = (
 ): string => {
   const url = new URL(urlString)
   const service = getServiceNameFromUrlString(urlString) || 'other'
-  const repositoryName =
-    url.pathname.endsWith('.git')
-      ? url.pathname.slice(0, -4)
-      : url.pathname
+  const repositoryName = url.pathname.endsWith('.git')
+    ? url.pathname.slice(0, -4)
+    : url.pathname
 
   const repoLocation = `./repositories/${username}/${service}${repositoryName}`
   return repoLocation
 }
-export const getRepoNameFromUrlString = (
-  urlString: string
-): string => {
+export const getRepoNameFromUrlString = (urlString: string): string => {
   const url = new URL(urlString)
-  const repositoryName =
-    url.pathname.endsWith('.git')
-      ? url.pathname.slice(0, -4)
-      : url.pathname
+  const repositoryName = url.pathname.endsWith('.git')
+    ? url.pathname.slice(0, -4)
+    : url.pathname
   return repositoryName
 }
 
@@ -109,31 +109,42 @@ export const getRepoLocationFromRepoName = (
   return repoLocation
 }
 
-export const getServiceNameFromUrlString = (urlString: string): ServiceName | undefined => {
+export const getServiceNameFromUrlString = (
+  urlString: string
+): ServiceName | undefined => {
   if (urlString.includes('github')) return 'github'
   if (urlString.includes('gitlab')) return 'gitlab'
   if (urlString.includes('bitbucket')) return 'bitbucket'
   return undefined
 }
 
-export const getServiceTokenFromContext = (serviceName: string, context: AppContext): string | undefined => {
+export const getServiceTokenFromContext = (
+  serviceName: string,
+  context: AppContext
+): string | undefined => {
   switch (serviceName) {
-    case 'github': return context.githubToken;
-    case 'bitbucket': return context.bitbucketToken;
-    case 'gitlab': return context.gitlabToken;
-    default: return undefined;
+    case 'github':
+      return context.githubToken
+    case 'bitbucket':
+      return context.bitbucketToken
+    case 'gitlab':
+      return context.gitlabToken
+    default:
+      return undefined
   }
 }
 
 /**
- * 
+ *
  * @param fileName: string
- * @param context: AppContext 
- * 
- * @returns usedService, gitUsername, email, repositoryName, repoLocation 
+ * @param context: AppContext
+ *
+ * @returns usedService, gitUsername, email, repositoryName, repoLocation
  */
-export const extractUserForCommit = (fileName: string, context: AppContext): UserForCommit => {
-  console.log('filename is: ', fileName)
+export const extractUserForCommit = (
+  fileName: string,
+  context: AppContext
+): UserForCommit => {
   const usedService = getServiceFromFilePath(fileName)
   const currentService = context.currentUser.services?.find(
     (s) => s.serviceName === usedService
@@ -154,8 +165,7 @@ export const extractUserForCommit = (fileName: string, context: AppContext): Use
     gitUsername,
     email,
     repositoryName,
-    repoLocation
+    repoLocation,
   }
   return userForCommit
 }
-

--- a/frontend/src/components/Editor.test.tsx
+++ b/frontend/src/components/Editor.test.tsx
@@ -1,25 +1,12 @@
-import React from 'react'
-
-import Editor from './editView/Editor'
-
 import { MockedProvider } from '@apollo/client/testing'
-
-import { render, cleanup } from '@testing-library/react'
+import { cleanup, render } from '@testing-library/react'
+import React from 'react'
+import Editor from './editView/Editor'
 
 // these bypass errors with mockedprovider component running out of mocks.
 // better definitely exist, for example giving the mocked responses by hand
 jest.mock('../hooks/useUser', () => () => ({ user: 'test', loading: false }))
 jest.mock('./editView/ServiceConnected', () => () => <div />)
-
-const unConflictedContent =
-  'just\n' + 'normal\n' + 'unconflicted\n' + 'content\n'
-
-const conflictedContent =
-  '<<<<<<< HEAD\n' +
-  'current changes\n' +
-  '=======\n' +
-  'incoming changes\n' +
-  '>>>>>>> commit id\n'
 
 const filename = 'filename'
 const commitMessage = 'commitMessage'
@@ -35,7 +22,8 @@ describe('Editor -component', () => {
     const { getByText } = render(
       <MockedProvider>
         <Editor
-          fileContent={unConflictedContent}
+          isConflicted={false}
+          fileContent={'content'}
           filename={filename}
           commitMessage={commitMessage}
           cloneUrl={cloneUrl}
@@ -55,7 +43,8 @@ describe('Editor -component', () => {
     const { getByText } = render(
       <MockedProvider>
         <Editor
-          fileContent={conflictedContent}
+          isConflicted={true}
+          fileContent={'conflicted content'}
           filename={filename}
           commitMessage={commitMessage}
           cloneUrl={cloneUrl}

--- a/frontend/src/components/editView/ConflictedBottomBar.tsx
+++ b/frontend/src/components/editView/ConflictedBottomBar.tsx
@@ -1,0 +1,107 @@
+import { Button, createStyles, makeStyles } from '@material-ui/core'
+import React, { useState } from 'react'
+import useSaveDialog from '../../hooks/useSaveDialog'
+import LatestCommit from './LatestCommit'
+import useDiffEditor from './MonacoDiffEditor/useDiffEditor'
+import MergeDialog from './saveDialogs/MergeDialog'
+import ServiceConnected from './ServiceConnected'
+
+interface Props {
+  cloneUrl: string
+  currentBranch: string
+  original: string
+  currentService: string
+  commitMessage: string
+}
+
+const ConflictedEditorBottomBar = ({
+  commitMessage,
+  currentBranch,
+  currentService,
+  cloneUrl,
+  original,
+}: Props) => {
+  const {
+    dialogOpen,
+    dialogError,
+    handleDialogClose,
+    setDialogError,
+    handleDialogOpen,
+  } = useSaveDialog()
+
+  const [waitingToMerge, setWaitingToMerge] = useState(false)
+
+  const classes = stylesInUse()
+
+  const { mergeConflictExists, saveMergeEdit, mutationMergeLoading } =
+    useDiffEditor(original, cloneUrl)
+
+  const handleDialogSubmit = async (newCommitMessage: string) => {
+    try {
+      setWaitingToMerge(true)
+      await saveMergeEdit({
+        variables: {
+          files: [],
+          commitMessage: newCommitMessage,
+        },
+      })
+      handleDialogClose()
+      setDialogError(undefined)
+    } catch (error) {
+      const dialogError = {
+        title: `An error occurred while merging`,
+        message: '',
+      }
+
+      if (error instanceof Error) {
+        dialogError.message = `More info: ${error.message}`
+      }
+
+      setDialogError(dialogError)
+    } finally {
+      setWaitingToMerge(false)
+    }
+  }
+
+  return (
+    <>
+      <MergeDialog
+        open={dialogOpen}
+        handleClose={handleDialogClose}
+        handleSubmit={handleDialogSubmit}
+        currentBranch={currentBranch}
+        error={dialogError}
+        waitingToMerge={waitingToMerge}
+      />
+
+      <div className={classes.saveGroup}>
+        <div className={classes.buttonAndStatus}>
+          <Button
+            color="primary"
+            variant="contained"
+            disabled={mutationMergeLoading || mergeConflictExists}
+            onClick={handleDialogOpen}
+          >
+            Merge
+          </Button>
+          <ServiceConnected service={currentService} />
+        </div>
+        <LatestCommit commitMessage={commitMessage} />
+      </div>
+    </>
+  )
+}
+
+const stylesInUse = makeStyles(() =>
+  createStyles({
+    saveGroup: {
+      margin: '10px 20px',
+    },
+    buttonAndStatus: {
+      display: 'flex',
+      alignItems: 'center',
+    },
+  })
+)
+
+export default ConflictedEditorBottomBar

--- a/frontend/src/components/editView/EditView.tsx
+++ b/frontend/src/components/editView/EditView.tsx
@@ -60,6 +60,10 @@ const EditView = ({ cloneUrl }: Props) => {
     const currentService = repoStateData.repoState.service
     const files = repoStateData.repoState.files
     const filename = location.search.slice(3)
+    const isConflicted =
+      repoStateData.repoState.gitStatus.conflicted?.some((name) =>
+        filename.includes(name)
+      ) ?? false
 
     const file = files.find((e) => e.name === filename)
 
@@ -73,6 +77,7 @@ const EditView = ({ cloneUrl }: Props) => {
     return (
       <Editor
         fileContent={fileContent}
+        isConflicted={isConflicted}
         filename={filename}
         commitMessage={commitMessage}
         cloneUrl={urlToClone}

--- a/frontend/src/components/editView/EditView.tsx
+++ b/frontend/src/components/editView/EditView.tsx
@@ -6,6 +6,7 @@ import { CLONE_REPO, ME, REPO_STATE } from '../../graphql/queries'
 import { MeQueryResult, RepoStateQueryResult } from '../../types'
 import AuthenticateDialog from '../AuthenticateDialog'
 import Editor from './Editor'
+import FileProvider from './FileProvider'
 import Sidebar from './Sidebar'
 
 interface LocationState {
@@ -75,16 +76,18 @@ const EditView = ({ cloneUrl }: Props) => {
     const commitMessage = repoStateData.repoState.commitMessage
 
     return (
-      <Editor
-        fileContent={fileContent}
-        isConflicted={isConflicted}
-        filename={filename}
-        commitMessage={commitMessage}
-        cloneUrl={urlToClone}
-        currentBranch={currentBranch}
-        currentService={currentService}
-        onMergeError={repoStateQuery}
-      />
+      <FileProvider cloneUrl={cloneUrl ?? ''}>
+        <Editor
+          fileContent={fileContent}
+          isConflicted={isConflicted}
+          filename={filename}
+          commitMessage={commitMessage}
+          cloneUrl={urlToClone}
+          currentBranch={currentBranch}
+          currentService={currentService}
+          onMergeError={repoStateQuery}
+        />
+      </FileProvider>
     )
   }
 

--- a/frontend/src/components/editView/Editor.tsx
+++ b/frontend/src/components/editView/Editor.tsx
@@ -3,7 +3,6 @@ import { loader } from '@monaco-editor/react'
 import React, { useEffect } from 'react'
 import { initMonaco, initLanguageClient } from '../../utils/monacoInitializer'
 import MonacoDiffEditor from './MonacoDiffEditor'
-import useMergeConflictDetector from './MonacoDiffEditor/useMergeConflictDetector'
 import MonacoEditor from './MonacoEditor/MonacoEditor'
 
 import VsCodeDarkTheme from '../../styles/editor-themes/vs-dark-plus-theme'
@@ -12,6 +11,7 @@ import VsCodeLightTheme from '../../styles/editor-themes/vs-light-plus-theme'
 import { SimpleLanguageInfoProvider } from '../../utils/providers'
 
 interface EditorProps {
+  isConflicted: boolean
   fileContent: string
   filename: string
   commitMessage: string
@@ -24,14 +24,13 @@ interface EditorProps {
 const Editor = ({
   fileContent,
   filename,
+  isConflicted,
   commitMessage,
   cloneUrl,
   onMergeError,
   currentBranch,
   currentService,
 }: EditorProps) => {
-  const mergeConflictExists = useMergeConflictDetector(fileContent)
-
   const classes = useStyles()
 
   const providerRef = React.useRef<SimpleLanguageInfoProvider | null>(null)
@@ -58,7 +57,7 @@ const Editor = ({
     }
   }
 
-  if (mergeConflictExists) {
+  if (isConflicted) {
     return (
       <div className={classes.editor}>
         <MonacoDiffEditor

--- a/frontend/src/components/editView/EditorBottomBar.tsx
+++ b/frontend/src/components/editView/EditorBottomBar.tsx
@@ -6,6 +6,7 @@ import {
 } from '@material-ui/core'
 import React, { useState } from 'react'
 import useSaveDialog from '../../hooks/useSaveDialog'
+import { useFiles } from './FileProvider'
 import LatestCommit from './LatestCommit'
 import useEditor from './MonacoEditor/useMonacoEditor'
 import ResetButtons from './ResetButtons'
@@ -36,6 +37,8 @@ const EditorBottomBar = ({
 
   const classes = stylesInUse()
 
+  const { modifiedFiles } = useFiles()
+
   const pullProps = useSaveDialog()
 
   const {
@@ -65,7 +68,7 @@ const EditorBottomBar = ({
       setWaitingToSave(true)
       await saveChanges({
         variables: {
-          files: [],
+          files: modifiedFiles.map(({ name, content }) => ({ name, content })),
           branch: branchName,
           commitMessage: newCommitMessage,
         },

--- a/frontend/src/components/editView/EditorBottomBar.tsx
+++ b/frontend/src/components/editView/EditorBottomBar.tsx
@@ -1,0 +1,200 @@
+import {
+  Button,
+  CircularProgress,
+  createStyles,
+  makeStyles,
+} from '@material-ui/core'
+import React, { useState } from 'react'
+import useSaveDialog from '../../hooks/useSaveDialog'
+import LatestCommit from './LatestCommit'
+import useEditor from './MonacoEditor/useMonacoEditor'
+import ResetButtons from './ResetButtons'
+import PullDialog from './saveDialogs/PullDialog'
+import SaveDialog from './saveDialogs/SaveDialog'
+import ServiceConnected from './ServiceConnected'
+
+interface Props {
+  cloneUrl: string
+  currentBranch: string
+  filename: string
+  currentService: string
+  commitMessage: string
+  autosaving: boolean
+  onMergeError: () => void
+}
+
+const EditorBottomBar = ({
+  cloneUrl,
+  currentBranch,
+  filename,
+  onMergeError,
+  currentService,
+  commitMessage,
+  autosaving,
+}: Props) => {
+  const [waitingToSave, setWaitingToSave] = useState(false)
+
+  const classes = stylesInUse()
+
+  const pullProps = useSaveDialog()
+
+  const {
+    dialogOpen,
+    dialogError,
+    handleDialogClose,
+    setDialogError,
+    handleDialogOpen,
+  } = useSaveDialog()
+
+  const {
+    saveChanges,
+    pullRepo,
+    mutationSaveLoading,
+    pullLoading,
+    commitChanges,
+    resetAll,
+  } = useEditor(cloneUrl)
+
+  const handleDialogSubmit = async (
+    createNewBranch: boolean,
+    newBranch: string,
+    newCommitMessage: string
+  ) => {
+    const branchName = createNewBranch ? newBranch : currentBranch
+    try {
+      setWaitingToSave(true)
+      await saveChanges({
+        variables: {
+          files: [],
+          branch: branchName,
+          commitMessage: newCommitMessage,
+        },
+      })
+      handleDialogClose()
+      setDialogError(undefined)
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        error.message === 'Merge conflict detected'
+      ) {
+        setDialogError({
+          title: `Merge conflict on branch ${branchName}`,
+          message:
+            'Cannot push to selected branch. Create a new one or resolve the conflicts.',
+        })
+      }
+    } finally {
+      setWaitingToSave(false)
+    }
+  }
+
+  const handlePull = async () => {
+    try {
+      await pullRepo({ variables: { repoUrl: cloneUrl } })
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        error.message.includes(
+          'Please commit your changes or stash them before you merge'
+        )
+      ) {
+        pullProps.setDialogError({
+          title: 'Error Pulling',
+          message: error.message,
+        })
+        pullProps.handleDialogOpen()
+      }
+    }
+  }
+
+  const handleCommitAndPull = async (commitMessage: string) => {
+    await commitChanges({
+      variables: {
+        url: cloneUrl,
+        commitMessage: commitMessage,
+        fileName: filename,
+      },
+    })
+    await handlePull()
+    pullProps.handleDialogClose()
+  }
+
+  const handleReset = async () => {
+    await resetAll({
+      variables: {
+        url: cloneUrl,
+      },
+    })
+  }
+
+  const handleResetAndPull = async () => {
+    await handleReset()
+    await handlePull()
+    pullProps.handleDialogClose()
+  }
+
+  return (
+    <>
+      <SaveDialog
+        open={dialogOpen}
+        handleClose={handleDialogClose}
+        handleSubmit={handleDialogSubmit}
+        onResolve={onMergeError}
+        currentBranch={currentBranch}
+        error={dialogError}
+        waitingToSave={waitingToSave}
+      />
+      <PullDialog
+        open={pullProps.dialogOpen}
+        handleClose={pullProps.handleDialogClose}
+        handleSubmit={handleCommitAndPull}
+        handleResetAll={handleResetAndPull}
+        error={pullProps.dialogError}
+      />
+      <div className={classes.saveGroup}>
+        <div className={classes.buttonAndStatus}>
+          <Button
+            style={{ marginRight: 5 }}
+            color="secondary"
+            variant="contained"
+            onClick={handlePull}
+            disabled={pullLoading || mutationSaveLoading}
+          >
+            Pull
+          </Button>
+          <Button
+            color="primary"
+            variant="contained"
+            disabled={pullLoading || mutationSaveLoading}
+            onClick={handleDialogOpen}
+          >
+            Save
+          </Button>
+          <ServiceConnected service={currentService} />
+          <ResetButtons cloneUrl={cloneUrl} filename={filename} />
+        </div>
+        <LatestCommit commitMessage={commitMessage} />
+        {autosaving && (
+          <div>
+            <CircularProgress size={10} />
+            <span> Saving...</span>
+          </div>
+        )}
+      </div>
+    </>
+  )
+}
+
+const stylesInUse = makeStyles(() =>
+  createStyles({
+    saveGroup: {
+      margin: '10px 20px',
+    },
+    buttonAndStatus: {
+      display: 'flex',
+      alignItems: 'center',
+    },
+  })
+)
+
+export default EditorBottomBar

--- a/frontend/src/components/editView/FileProvider.tsx
+++ b/frontend/src/components/editView/FileProvider.tsx
@@ -1,0 +1,75 @@
+import { useQuery } from '@apollo/client'
+import React from 'react'
+import { REPO_STATE } from '../../graphql/queries'
+import { File, RepoStateQueryResult } from '../../types'
+
+interface FileContext {
+  files: File[]
+  conflictedFiles: File[]
+  modifiedFiles: File[]
+  solvedConflicts: File[]
+  allSolved: boolean
+  conflictExists: boolean
+}
+
+const defaultValue: FileContext = {
+  files: [],
+  conflictedFiles: [],
+  modifiedFiles: [],
+  solvedConflicts: [],
+  allSolved: false,
+  conflictExists: false,
+}
+
+const FileContext = React.createContext<FileContext>(defaultValue)
+
+export const useFiles = () => React.useContext(FileContext)
+
+const FileProvider: React.FC<{ cloneUrl: string }> = ({
+  cloneUrl,
+  children,
+}) => {
+  const { data } = useQuery<RepoStateQueryResult>(REPO_STATE, {
+    fetchPolicy: 'network-only',
+    variables: { repoUrl: cloneUrl },
+  })
+
+  const returnValue = React.useMemo(() => {
+    if (!data) {
+      return defaultValue
+    }
+
+    const { files, gitStatus } = data.repoState
+
+    const conflictedFiles = files.filter(
+      (file) => !!gitStatus.conflicted?.find((f) => file.name.includes(f))
+    )
+    const modifiedFiles = files.filter(
+      (file) => !!gitStatus.modified?.find((f) => file.name.includes(f))
+    )
+    const solvedConflicts = conflictedFiles.filter((file) => {
+      const lines = file.content.split('\n')
+
+      return (
+        !lines.find((line) => line.startsWith('<<<<<<<')) ||
+        !lines.find((line) => line.startsWith('=======')) ||
+        !lines.find((line) => line.startsWith('>>>>>>>'))
+      )
+    })
+
+    return {
+      files,
+      conflictedFiles,
+      modifiedFiles,
+      solvedConflicts,
+      allSolved: conflictedFiles.length === solvedConflicts.length,
+      conflictExists: conflictedFiles.length > 0,
+    }
+  }, [data])
+
+  return (
+    <FileContext.Provider value={returnValue}>{children}</FileContext.Provider>
+  )
+}
+
+export default FileProvider

--- a/frontend/src/components/editView/MonacoDiffEditor/MonacoDiffEditor.tsx
+++ b/frontend/src/components/editView/MonacoDiffEditor/MonacoDiffEditor.tsx
@@ -75,8 +75,10 @@ const MonacoDiffEditor = ({
         updateTheme()
       }
       <ConflictedEditorBottomBar
+        filename={filename}
         cloneUrl={cloneUrl}
         original={original}
+        modified={modifiedContent}
         currentBranch={currentBranch}
         currentService={currentService}
         commitMessage={commitMessage}

--- a/frontend/src/components/editView/MonacoDiffEditor/MonacoDiffEditor.tsx
+++ b/frontend/src/components/editView/MonacoDiffEditor/MonacoDiffEditor.tsx
@@ -1,11 +1,8 @@
-import { Button, createStyles, makeStyles, useTheme } from '@material-ui/core'
+import { createStyles, makeStyles, useTheme } from '@material-ui/core'
 import { DiffEditor, Monaco } from '@monaco-editor/react'
 import { editor } from 'monaco-editor'
-import React, { useRef, useState } from 'react'
-import useSaveDialog from '../../../hooks/useSaveDialog'
-import LatestCommit from '../LatestCommit'
-import MergeDialog from '../saveDialogs/MergeDialog'
-import ServiceConnected from '../ServiceConnected'
+import React, { useRef } from 'react'
+import ConflictedEditorBottomBar from '../ConflictedBottomBar'
 import useDiffEditor from './useDiffEditor'
 
 interface Props {
@@ -20,13 +17,6 @@ interface Props {
 
 const stylesInUse = makeStyles(() =>
   createStyles({
-    saveGroup: {
-      margin: '10px 20px',
-    },
-    buttonAndStatus: {
-      display: 'flex',
-      alignItems: 'center',
-    },
     title: {
       height: '1rem',
       marginLeft: '20px',
@@ -45,25 +35,9 @@ const MonacoDiffEditor = ({
   currentService,
   updateTheme,
 }: Props) => {
-  const {
-    dialogOpen,
-    dialogError,
-    handleDialogClose,
-    setDialogError,
-    handleDialogOpen,
-  } = useSaveDialog()
-
-  const [waitingToMerge, setWaitingToMerge] = useState(false)
-
   const classes = stylesInUse()
 
-  const {
-    setupCodeLens,
-    mergeConflictExists,
-    saveMergeEdit,
-    modifiedContent,
-    mutationMergeLoading,
-  } = useDiffEditor(original, cloneUrl)
+  const { setupCodeLens, modifiedContent } = useDiffEditor(original, cloneUrl)
 
   const theme = useTheme()
 
@@ -76,40 +50,6 @@ const MonacoDiffEditor = ({
     editorRef.current = editor
 
     setupCodeLens(editor, monaco)
-  }
-
-  const handleDialogSubmit = async (newCommitMessage: string) => {
-    if (editorRef.current) {
-      try {
-        setWaitingToMerge(true)
-        await saveMergeEdit({
-          variables: {
-            files: [
-              {
-                name: filename,
-                content: editorRef.current.getModifiedEditor().getValue(),
-              },
-            ],
-            commitMessage: newCommitMessage,
-          },
-        })
-        handleDialogClose()
-        setDialogError(undefined)
-      } catch (error) {
-        const dialogError = {
-          title: `An error occurred while merging`,
-          message: '',
-        }
-
-        if (error instanceof Error) {
-          dialogError.message = `More info: ${error.message}`
-        }
-
-        setDialogError(dialogError)
-      } finally {
-        setWaitingToMerge(false)
-      }
-    }
   }
 
   const options: editor.IDiffEditorConstructionOptions = {
@@ -134,29 +74,13 @@ const MonacoDiffEditor = ({
         // Updating the theme here so we override things set by <Editor>
         updateTheme()
       }
-      <MergeDialog
-        open={dialogOpen}
-        handleClose={handleDialogClose}
-        handleSubmit={handleDialogSubmit}
+      <ConflictedEditorBottomBar
+        cloneUrl={cloneUrl}
+        original={original}
         currentBranch={currentBranch}
-        error={dialogError}
-        waitingToMerge={waitingToMerge}
+        currentService={currentService}
+        commitMessage={commitMessage}
       />
-
-      <div className={classes.saveGroup}>
-        <div className={classes.buttonAndStatus}>
-          <Button
-            color="primary"
-            variant="contained"
-            disabled={mutationMergeLoading || mergeConflictExists}
-            onClick={handleDialogOpen}
-          >
-            Merge
-          </Button>
-          <ServiceConnected service={currentService} />
-          <LatestCommit commitMessage={commitMessage} />
-        </div>
-      </div>
     </div>
   )
 }

--- a/frontend/src/components/editView/MonacoEditor/MonacoEditor.tsx
+++ b/frontend/src/components/editView/MonacoEditor/MonacoEditor.tsx
@@ -3,7 +3,9 @@ import Editor from '@monaco-editor/react'
 import { editor } from 'monaco-editor'
 import React, { useRef } from 'react'
 import useAutoSave from '../../../hooks/useAutoSave'
+import ConflictedEditorBottomBar from '../ConflictedBottomBar'
 import EditorBottomBar from '../EditorBottomBar'
+import { useFiles } from '../FileProvider'
 
 interface Props {
   content: string
@@ -39,6 +41,8 @@ const MonacoEditor = ({
 }: Props) => {
   const classes = stylesInUse()
 
+  const { conflictExists } = useFiles()
+
   const [onEditorChange, autosaving] = useAutoSave(filename, cloneUrl)
 
   const theme = useTheme()
@@ -66,15 +70,27 @@ const MonacoEditor = ({
         // Updating the theme here so we override things set by <Editor>
         updateTheme()
       }
-      <EditorBottomBar
-        cloneUrl={cloneUrl}
-        currentBranch={currentBranch}
-        filename={filename}
-        currentService={currentService}
-        autosaving={autosaving}
-        onMergeError={onMergeError}
-        commitMessage={commitMessage}
-      />
+      {conflictExists ? (
+        <ConflictedEditorBottomBar
+          filename={filename}
+          cloneUrl={cloneUrl}
+          currentBranch={currentBranch}
+          currentService={currentService}
+          commitMessage={commitMessage}
+          original={content}
+          modified={content}
+        />
+      ) : (
+        <EditorBottomBar
+          cloneUrl={cloneUrl}
+          currentBranch={currentBranch}
+          filename={filename}
+          currentService={currentService}
+          autosaving={autosaving}
+          onMergeError={onMergeError}
+          commitMessage={commitMessage}
+        />
+      )}
     </div>
   )
 }

--- a/frontend/src/components/editView/MonacoEditor/MonacoEditor.tsx
+++ b/frontend/src/components/editView/MonacoEditor/MonacoEditor.tsx
@@ -1,21 +1,9 @@
-import {
-  Button,
-  CircularProgress,
-  createStyles,
-  makeStyles,
-  useTheme,
-} from '@material-ui/core'
-// import { GitHub } from '@material-ui/icons'
+import { createStyles, makeStyles, useTheme } from '@material-ui/core'
 import Editor from '@monaco-editor/react'
 import { editor } from 'monaco-editor'
-import React, { useRef, useState } from 'react'
+import React, { useRef } from 'react'
 import useAutoSave from '../../../hooks/useAutoSave'
-import useSaveDialog from '../../../hooks/useSaveDialog'
-import LatestCommit from '../LatestCommit'
-import PullDialog from '../saveDialogs/PullDialog'
-import SaveDialog from '../saveDialogs/SaveDialog'
-import ServiceConnected from '../ServiceConnected'
-import useEditor from './useMonacoEditor'
+import EditorBottomBar from '../EditorBottomBar'
 
 interface Props {
   content: string
@@ -30,22 +18,12 @@ interface Props {
 
 const stylesInUse = makeStyles(() =>
   createStyles({
-    saveGroup: {
-      margin: '10px 20px',
-    },
-    buttonAndStatus: {
-      display: 'flex',
-      alignItems: 'center',
-    },
     title: {
       height: '1rem',
       marginLeft: '20px',
       display: 'flex',
       alignItems: 'center',
     },
-    resetButton: {
-      color: "red"
-    }
   })
 )
 
@@ -59,133 +37,16 @@ const MonacoEditor = ({
   currentService,
   updateTheme,
 }: Props) => {
-  const [waitingToSave, setWaitingToSave] = useState(false)
-
-  const {
-    dialogOpen,
-    dialogError,
-    handleDialogClose,
-    setDialogError,
-    handleDialogOpen,
-  } = useSaveDialog()
-
-  const pullProps = useSaveDialog()
-
   const classes = stylesInUse()
 
   const [onEditorChange, autosaving] = useAutoSave(filename, cloneUrl)
-
-  const {
-    saveChanges,
-    pullRepo,
-    mutationSaveLoading,
-    pullLoading,
-    commitChanges,
-    resetAll,
-    resetFile
-  } = useEditor(cloneUrl)
 
   const theme = useTheme()
 
   const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null)
 
   const handleEditorDidMount = (editor: editor.IStandaloneCodeEditor) => {
-    console.log('mounted')
     editorRef.current = editor
-  }
-
-  const handleDialogSubmit = async (
-    createNewBranch: boolean,
-    newBranch: string,
-    newCommitMessage: string
-  ) => {
-    if (editorRef.current) {
-      const branchName = createNewBranch ? newBranch : currentBranch
-      try {
-        setWaitingToSave(true)
-        await saveChanges({
-          variables: {
-            files: [
-              {
-                name: filename,
-                content: editorRef.current.getValue(),
-              },
-            ],
-            branch: branchName,
-            commitMessage: newCommitMessage,
-          },
-        })
-        handleDialogClose()
-        setDialogError(undefined)
-      } catch (error) {
-        if (
-          error instanceof Error &&
-          error.message === 'Merge conflict detected'
-        ) {
-          setDialogError({
-            title: `Merge conflict on branch ${branchName}`,
-            message:
-              'Cannot push to selected branch. Create a new one or resolve the conflicts.',
-          })
-        }
-      } finally {
-        setWaitingToSave(false)
-      }
-    }
-  }
-
-  const handlePull = async () => {
-    try {
-      await pullRepo({ variables: { repoUrl: cloneUrl } })
-    } catch (error) {
-      if (
-        error instanceof Error &&
-        error.message.includes(
-          'Please commit your changes or stash them before you merge'
-        )
-      ) {
-        pullProps.setDialogError({
-          title: 'Error Pulling',
-          message: error.message,
-        })
-        pullProps.handleDialogOpen()
-      }
-    }
-  }
-
-  const handleCommitAndPull = async (commitMessage: string) => {
-    await commitChanges({
-      variables: {
-        url: cloneUrl,
-        commitMessage: commitMessage,
-        fileName: filename
-      },
-    })
-    await handlePull()
-    pullProps.handleDialogClose()
-  }
-
-  const handleReset = async () => {
-    await resetAll({
-      variables: {
-        url: cloneUrl
-      },
-    })
-  }
-
-  const handleResetAndPull = async () => {
-    await handleReset()
-    await handlePull()
-    pullProps.handleDialogClose()
-  }
-
-  const handleResetFile = async () => {
-    await resetFile({
-      variables: {
-        url: cloneUrl,
-        fileName: filename
-      }
-    })
   }
 
   return (
@@ -205,71 +66,15 @@ const MonacoEditor = ({
         // Updating the theme here so we override things set by <Editor>
         updateTheme()
       }
-      <SaveDialog
-        open={dialogOpen}
-        handleClose={handleDialogClose}
-        handleSubmit={handleDialogSubmit}
-        onResolve={onMergeError}
+      <EditorBottomBar
+        cloneUrl={cloneUrl}
         currentBranch={currentBranch}
-        error={dialogError}
-        waitingToSave={waitingToSave}
+        filename={filename}
+        currentService={currentService}
+        autosaving={autosaving}
+        onMergeError={onMergeError}
+        commitMessage={commitMessage}
       />
-      <PullDialog
-        open={pullProps.dialogOpen}
-        handleClose={pullProps.handleDialogClose}
-        handleSubmit={handleCommitAndPull}
-        handleResetAll={handleResetAndPull}
-        error={pullProps.dialogError}
-      />
-      <div className={classes.saveGroup}>
-        <div className={classes.buttonAndStatus}>
-          <Button
-            style={{ marginRight: 5 }}
-            color="secondary"
-            variant="contained"
-            onClick={handlePull}
-            disabled={pullLoading || mutationSaveLoading}
-          >
-            Pull
-          </Button>
-          <Button
-            color="primary"
-            variant="contained"
-            disabled={pullLoading || mutationSaveLoading}
-            onClick={handleDialogOpen}
-          >
-            Save
-          </Button>
-          <ServiceConnected service={currentService} />
-          <Button
-            style={{ marginLeft: 25 }}
-            className={ classes.resetButton }
-            variant="outlined"
-            size="small"
-            disabled={pullLoading || mutationSaveLoading}
-            onClick={handleResetFile}
-          >
-            Reset File
-          </Button>
-          <Button
-            style={{ marginLeft: 25 }}
-            className={ classes.resetButton }
-            variant="outlined"
-            size="small"
-            disabled={pullLoading || mutationSaveLoading}
-            onClick={handleReset}
-          >
-            Reset Repo
-          </Button>
-        </div>
-        <LatestCommit commitMessage={commitMessage} />
-        {autosaving && (
-          <div>
-            <CircularProgress size={10} />
-            <span> Saving...</span>
-          </div>
-        )}
-      </div>
     </div>
   )
 }

--- a/frontend/src/components/editView/ResetButtons.tsx
+++ b/frontend/src/components/editView/ResetButtons.tsx
@@ -1,0 +1,68 @@
+import { Button, createStyles, makeStyles } from '@material-ui/core'
+import React from 'react'
+import useEditor from './MonacoEditor/useMonacoEditor'
+
+const ResetButtons = ({
+  cloneUrl,
+  filename,
+}: {
+  cloneUrl: string
+  filename: string
+}) => {
+  const { mutationSaveLoading, pullLoading, resetAll, resetFile } =
+    useEditor(cloneUrl)
+
+  const classes = stylesInUse()
+
+  const handleResetFile = async () => {
+    await resetFile({
+      variables: {
+        url: cloneUrl,
+        fileName: filename,
+      },
+    })
+  }
+
+  const handleReset = async () => {
+    await resetAll({
+      variables: {
+        url: cloneUrl,
+      },
+    })
+  }
+
+  return (
+    <>
+      <Button
+        style={{ marginLeft: 25 }}
+        className={classes.resetButton}
+        variant="outlined"
+        size="small"
+        disabled={pullLoading || mutationSaveLoading}
+        onClick={handleResetFile}
+      >
+        Reset File
+      </Button>
+      <Button
+        style={{ marginLeft: 25 }}
+        className={classes.resetButton}
+        variant="outlined"
+        size="small"
+        disabled={pullLoading || mutationSaveLoading}
+        onClick={handleReset}
+      >
+        Reset Repo
+      </Button>
+    </>
+  )
+}
+
+const stylesInUse = makeStyles(() =>
+  createStyles({
+    resetButton: {
+      color: 'red',
+    },
+  })
+)
+
+export default ResetButtons

--- a/frontend/src/hooks/useAutoSave.ts
+++ b/frontend/src/hooks/useAutoSave.ts
@@ -3,7 +3,7 @@ import { useDebouncedCallback } from 'use-debounce'
 import useSave from './useSave'
 
 /**
- * Autosaves periodically and when not moving the cursor for the set interval
+ * Autosaves when not moving the cursor for the set interval
  *
  * @param filename name of the file being edited
  * @param repoUrl repository url in backend
@@ -14,9 +14,7 @@ const useAutoSave = (filename: string, repoUrl: string) => {
 
   const interval = 1000
 
-  const debouncedAutoSave = useDebouncedCallback(save, interval, {
-    maxWait: 5000,
-  })
+  const debouncedAutoSave = useDebouncedCallback(save, interval)
 
   React.useEffect(
     // Cancels autosave when user changes the file that is being edited.


### PR DESCRIPTION
- Fix autosave bug
- Solve multiple merge conflicts with "Mark solved" button (merge-button activates when all are solved)
- Refactor editor components (less repetition, and show merge-option instead of save when there is an unsolved conflict)
- Include multiple files in commit operations (saveChanges/saveMergeEdit). Currently adds all conflicted files when merging, and all modified files when pushing. TODO: checkbox logic to pick which modified files to include