### PR TITLE
Autosave interval minmax

### DIFF
--- a/backend/src/schema/settings.ts
+++ b/backend/src/schema/settings.ts
@@ -17,6 +17,8 @@ const typeDef = `
       name: String!
       value: Int!
       unit: String
+      min: Int
+      max: Int
     }
     type PluginSetting {
       name: String!

--- a/backend/src/schema/settings.ts
+++ b/backend/src/schema/settings.ts
@@ -28,6 +28,8 @@ const typeDef = `
       name: String!
       value: Int!
       unit: String!
+      min: Int
+      max: Int
     }
     input Pinput {
       name: String!
@@ -56,7 +58,6 @@ const resolvers = {
       _root: unknown,
       settings: SettingsObject
     ): string => {
-
       try {
         writeFileSync('src/utils/settings.json', JSON.stringify(settings, null, 4))
       } catch (error) {

--- a/backend/src/types/settings.ts
+++ b/backend/src/types/settings.ts
@@ -8,7 +8,9 @@ export interface SettingsObject {
 export interface MiscSettingObject {
   name: string
   value: number
-  unit: string 
+  unit: string
+  min?: number
+  max?: number
 }
 
 export interface PluginSettingObject {

--- a/backend/src/utils/settings.json
+++ b/backend/src/utils/settings.json
@@ -4,7 +4,9 @@
             {
                 "name": "Autosave Interval",
                 "value": 500,
-                "unit": "ms"
+                "unit": "ms",
+                "min": 500,
+                "max": 60000
             }
         ],
         "plugins": [

--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -221,7 +221,10 @@ const SettingsPage = ({ user }: Props) => {
         Save settings
       </Button>
       <p>
-        {changesMade ? 'Settings changed. Please save.' : ''}
+        {flag ? 'Invalid input value.' : '' } 
+      </p>
+      <p>
+        {changesMade && !flag ? 'Settings changed. Please save.' : ''}
       </p>
       <p>
         {saved ? 'Saved successfully. Refreshing page...' : ''}

--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -21,13 +21,30 @@ interface Props {
   user: UserType | undefined
 }
 
+const valueIsWithinRange = (value: number, min?: number, max?: number): boolean => {
+  if (min && value < min) {
+    return false
+  }
+
+  if (max && value > max) {
+    return false
+  }
+
+  return true
+}
+
 const MiscObject = ({ name, value, min, max, parentCallback, unit }: {
   name: string,
   value: number,
   min?: number,
   max?: number
   unit?: string,
-  parentCallback: (name: string, value: number) => void,
+  parentCallback: (
+    name: string,
+    value: number,
+    min?: number,
+    max?: number
+  ) => void,
 }) => {
 
   useEffect(() => {
@@ -37,7 +54,7 @@ const MiscObject = ({ name, value, min, max, parentCallback, unit }: {
   const [fieldValue, setFieldValue] = useState(value)
 
   const handleFieldValueChange = (incomingValue: string) => {
-    parentCallback(name, parseInt(incomingValue))
+    parentCallback(name, parseInt(incomingValue), min, max)
     setFieldValue(parseInt(incomingValue))
   }
 
@@ -98,6 +115,7 @@ const SettingsPage = ({ user }: Props) => {
 
   const [saved, setSaved] = useState(false)
   const [changesMade, setChangesMade] = useState(false)
+  const [flag, setFlag] = useState(false)
 
   const [saveSettings] = useMutation(SAVE_SETTINGS)
 
@@ -134,7 +152,7 @@ const SettingsPage = ({ user }: Props) => {
     }, 500)
   }
 
-  const handleCallback = (name: string, value: boolean | number) => {
+  const handleCallback = (name: string, value: boolean | number, min?: number, max?: number) => {
     setChangesMade(true)
 
     switch (typeof value) {
@@ -147,6 +165,8 @@ const SettingsPage = ({ user }: Props) => {
         break;
 
       case "number":
+        setFlag(!valueIsWithinRange(value, min, max))
+
         const altMisc = settings.misc.map(m =>
           m.name === name ? { ...m, value: value } : m
         )
@@ -196,6 +216,7 @@ const SettingsPage = ({ user }: Props) => {
         name="save-settings-button"
         variant="contained"
         color="primary"
+        disabled={flag}
       >
         Save settings
       </Button>

--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -3,15 +3,17 @@ import { useMutation } from '@apollo/client'
 import { SAVE_SETTINGS } from '../graphql/mutations'
 import { GET_SETTINGS } from '../graphql/queries'
 
-import { 
-  Switch, 
-  TextField, 
-  Button } from '@material-ui/core'
+import {
+  Switch,
+  TextField,
+  Button
+} from '@material-ui/core'
 
-import { 
-  MiscSettingObject, 
+import {
+  MiscSettingObject,
   PluginSettingObject,
-  UserType } from '../types'
+  UserType
+} from '../types'
 
 import useSettings from '../hooks/useSettings'
 
@@ -19,25 +21,26 @@ interface Props {
   user: UserType | undefined
 }
 
-const MiscObject = ({ name, value, parentCallback, unit }: {
-  name: string, 
-  value: number, 
-  unit?: string, 
-  parentCallback: (name: string, value: number) => void, 
+const MiscObject = ({ name, value, min, max, parentCallback, unit }: {
+  name: string,
+  value: number,
+  min?: number,
+  max?: number
+  unit?: string,
+  parentCallback: (name: string, value: number) => void,
 }) => {
-  
+
   useEffect(() => {
-    setFieldValue(value) 
+    setFieldValue(value)
   }, [value])
-  
+
   const [fieldValue, setFieldValue] = useState(value)
-  
+
   const handleFieldValueChange = (incomingValue: string) => {
     parentCallback(name, parseInt(incomingValue))
     setFieldValue(parseInt(incomingValue))
   }
 
-  
   return (
     <div>
       <b>{name}</b>
@@ -48,30 +51,30 @@ const MiscObject = ({ name, value, parentCallback, unit }: {
         type="number"
         color="primary"
         onChange={({ target }) => handleFieldValueChange(target.value)}
-        inputProps={{ 'aria-label': 'primary checkbox' }}
-        />
+        inputProps={{ 'aria-label': 'primary checkbox', min: min, max: max }}
+      />
       {unit}
     </div>
   )
 }
 
-const PluginObject = ({ name, active, parentCallback }: { 
-  name: string, 
-  active: boolean, 
-  parentCallback: (name: string, value: boolean) => void, 
+const PluginObject = ({ name, active, parentCallback }: {
+  name: string,
+  active: boolean,
+  parentCallback: (name: string, value: boolean) => void,
 }) => {
 
   useEffect(() => {
-   setSwitchChecked(active) 
+    setSwitchChecked(active)
   }, [active])
-  
+
   const [switchChecked, setSwitchChecked] = useState(active)
-  
+
   const handleSwitchToggle = () => {
     parentCallback(name, !switchChecked)
     setSwitchChecked(!switchChecked)
   }
-  
+
   return (
     <div>
       <b>{name}</b>
@@ -89,13 +92,13 @@ const PluginObject = ({ name, active, parentCallback }: {
 }
 
 const SettingsPage = ({ user }: Props) => {
-  
-  const {settings: nestedSettings, setSettings} = useSettings()
+
+  const { settings: nestedSettings, setSettings } = useSettings()
   const settings = nestedSettings?.settings
-  
+
   const [saved, setSaved] = useState(false)
   const [changesMade, setChangesMade] = useState(false)
-  
+
   const [saveSettings] = useMutation(SAVE_SETTINGS)
 
   // Hides view from users that are not admins.
@@ -112,42 +115,44 @@ const SettingsPage = ({ user }: Props) => {
   const handleSubmit = async () => {
 
     try {
-      await saveSettings (
-        { variables: { settings: settings }, update: (cache) => { 
-           const updatedContent = { getSettings: settings }
-           cache.writeQuery({query: GET_SETTINGS, data: updatedContent})
-        }}
+      await saveSettings(
+        {
+          variables: { settings: settings }, update: (cache) => {
+            const updatedContent = { getSettings: settings }
+            cache.writeQuery({ query: GET_SETTINGS, data: updatedContent })
+          }
+        }
       )
     }
     catch (e) {
       console.log(e)
     }
-    
+
     setSaved(true)
     setTimeout(() => {
       window.location.reload()
     }, 500)
   }
 
-  const handleCallback = ( name: string, value: boolean | number ) => {
+  const handleCallback = (name: string, value: boolean | number) => {
     setChangesMade(true)
-    
+
     switch (typeof value) {
-      
+
       case "boolean":
         const altPlugins = settings.plugins.map(p =>
-          p.name === name ? {...p, active: value} : p
+          p.name === name ? { ...p, active: value } : p
         )
-        setSettings({ settings: {...settings, plugins: altPlugins}})
+        setSettings({ settings: { ...settings, plugins: altPlugins } })
         break;
-      
+
       case "number":
         const altMisc = settings.misc.map(m =>
-          m.name === name ? {...m, value: value} : m
+          m.name === name ? { ...m, value: value } : m
         )
-        setSettings({ settings: {...settings, misc: altMisc}})
+        setSettings({ settings: { ...settings, misc: altMisc } })
         break;
-        
+
     }
   }
 
@@ -159,49 +164,51 @@ const SettingsPage = ({ user }: Props) => {
     )
   }
 
-  
-    return (
+
+  return (
     <div>
       <h1> Admins only. </h1>
 
-      {settings.misc.map((m: MiscSettingObject) => 
-        <MiscObject 
-          key={m.name} 
-          name={m.name} 
-          value={m.value} 
-          unit={m.unit} 
+      {settings.misc.map((m: MiscSettingObject) =>
+        <MiscObject
+          key={m.name}
+          name={m.name}
+          value={m.value}
+          unit={m.unit}
+          min={m.min}
+          max={m.max}
           parentCallback={handleCallback}
-        /> 
-       )}
-
-      {settings.plugins.map((p: PluginSettingObject) => 
-        <PluginObject 
-          key={p.name} 
-          name={p.name} 
-          active={p.active} 
-          parentCallback={handleCallback}
-        /> 
+        />
       )}
-      
-      <Button 
+
+      {settings.plugins.map((p: PluginSettingObject) =>
+        <PluginObject
+          key={p.name}
+          name={p.name}
+          active={p.active}
+          parentCallback={handleCallback}
+        />
+      )}
+
+      <Button
         onClick={handleSubmit}
         id="save-settings-button"
         name="save-settings-button"
-        variant="contained" 
+        variant="contained"
         color="primary"
-        >
-          Save settings
+      >
+        Save settings
       </Button>
       <p>
-        {changesMade ? 'Settings changed. Please save.': ''}
+        {changesMade ? 'Settings changed. Please save.' : ''}
       </p>
       <p>
-        {saved ? 'Saved successfully. Refreshing page...': ''}
-      </p> 
-      
-      
-      </div>
+        {saved ? 'Saved successfully. Refreshing page...' : ''}
+      </p>
+
+
+    </div>
   )
 }
 
-export default SettingsPage 
+export default SettingsPage

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -4,7 +4,9 @@ export const DEFAULT_SETTINGS = {
             {
                 "name": "Autosave Interval",
                 "value": 1000,
-                "unit": "ms"
+                "unit": "ms",
+                "min": 500,
+                "max": 60000
             }
         ],
     

--- a/frontend/src/graphql/queries.ts
+++ b/frontend/src/graphql/queries.ts
@@ -97,7 +97,9 @@ export const GET_SETTINGS = gql`
       misc {
         name, 
         value, 
-        unit
+        unit,
+        min,
+        max
       }
       plugins {
         name,

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -46,7 +46,9 @@ export interface SettingsObject {
 export interface MiscSettingObject {
   name: string
   value: number
-  unit: string 
+  unit: string
+  min?: number
+  max?: number
 }
 
 export interface PluginSettingObject {


### PR DESCRIPTION
- extended misc settings type to have optional min / max values
- if min / max values are given in a misc setting object, user can not click past those values in the settings page  
- issue: user can manually type a value past the set min / max values, ~~and save such invalid setting~~
- upcoming fixes: validate user input  in back end before saving new settings, ~~disable "Save settings" button if invalid inputs are present~~ and inform user about the valid range